### PR TITLE
spes: props: Disable sensor debug logging

### DIFF
--- a/configs/props/vendor.prop
+++ b/configs/props/vendor.prop
@@ -252,7 +252,7 @@ ro.config.hw_quickpoweron_init=true
 sys.fflag.override.settings_seamless_transfer=true
 
 # Sensors
-persist.vendor.sensors.debug.ssc_qmi_debug=true
+persist.vendor.sensors.debug.ssc_qmi_debug=false
 persist.vendor.sensors.enable.bypass_worker=true
 persist.vendor.sensors.enable.rt_task=false
 persist.vendor.sensors.hal_trigger_ssr=false


### PR DESCRIPTION
Disable sensor debug logging in production to reduce log noise and improve performance.